### PR TITLE
Lume fixes

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -7,8 +7,7 @@ import mdx from "lume/plugins/mdx.ts";
 const site = lume({
   src: ".",
   dest: "_site",
-}, {
-  url: "https://tinyclouds.ry.deno.net",
+  location: new URL("https://tinyclouds.ry.deno.net"),
 });
 
 site.use(jsx());
@@ -20,16 +19,5 @@ site.use(slugify_urls());
 site.copy("colorize/", "colorize/");
 site.copy("residency/", "residency/");
 site.copy([".jpg", ".jpeg", ".png", ".pdf"]);
-
-// Set default layout for markdown posts (excluding index.page.ts)
-site.process([".md"], (pages) => {
-  for (const page of pages) {
-    if (
-      page.src.path !== "/index" && page.data.title && page.data.publish_date
-    ) {
-      page.data.layout = "post.tsx";
-    }
-  }
-});
 
 export default site;

--- a/_index.tsx
+++ b/_index.tsx
@@ -2,7 +2,10 @@ export const layout = "layout.tsx";
 export const title = "Ryan Dahl";
 
 export default function Home({ search }: Lume.Data) {
-  const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
+  const posts = search.pages(
+    "type=post publish_date!=undefined",
+    "publish_date=desc",
+  );
 
   return (
     <ul class="post-list">

--- a/_index.tsx
+++ b/_index.tsx
@@ -2,11 +2,7 @@ export const layout = "layout.tsx";
 export const title = "Ryan Dahl";
 
 export default function Home({ search }: Lume.Data) {
-  const posts = search.pages("src.path*=/posts/")
-    .filter((page) => page.publish_date)
-    .sort((a, b) =>
-      new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
-    );
+  const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
 
   return (
     <ul class="post-list">

--- a/_index.tsx
+++ b/_index.tsx
@@ -1,16 +1,16 @@
 export const layout = "layout.tsx";
 export const title = "Ryan Dahl";
 
-export default function Home({ search }: { search: any }) {
+export default function Home({ search }: Lume.Data) {
   const posts = search.pages("src.path*=/posts/")
-    .filter((page: any) => page.publish_date)
-    .sort((a: any, b: any) =>
+    .filter((page) => page.publish_date)
+    .sort((a, b) =>
       new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
     );
 
   return (
     <ul class="post-list">
-      {posts.map((post: any) => {
+      {posts.map((post) => {
         const formattedDate = new Intl.DateTimeFormat("en-US", {
           year: "numeric",
           month: "long",

--- a/feed.page.ts
+++ b/feed.page.ts
@@ -1,14 +1,14 @@
 export const url = "/feed";
 
-export default function ({ search }: { search: any }) {
+export default function ({ search }: Lume.Data) {
   // Generate RSS content for /feed to match original tinyclouds.org
   const posts = search.pages()
-    .filter((page: any) => page.title && page.publish_date)
-    .sort((a: any, b: any) =>
+    .filter((page) => page.title && page.publish_date)
+    .sort((a, b) =>
       new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
     );
 
-  const rssItems = posts.map((post: any) => {
+  const rssItems = posts.map((post) => {
     const url = `https://tinyclouds${post.url}`;
     const date = new Date(post.publish_date).toUTCString();
 

--- a/feed.page.ts
+++ b/feed.page.ts
@@ -2,7 +2,10 @@ export const url = "/feed";
 
 export default function ({ search }: Lume.Data, helpers: Lume.Helpers) {
   // Generate RSS content for /feed to match original tinyclouds.org
-  const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
+  const posts = search.pages(
+    "type=post publish_date!=undefined",
+    "publish_date=desc",
+  );
 
   const rssItems = posts.map((post) => {
     const url = helpers.url(post.url, true);

--- a/feed.page.ts
+++ b/feed.page.ts
@@ -1,11 +1,11 @@
 export const url = "/feed";
 
-export default function ({ search }: Lume.Data) {
+export default function ({ search }: Lume.Data, helpers: Lume.Helpers) {
   // Generate RSS content for /feed to match original tinyclouds.org
   const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
 
   const rssItems = posts.map((post) => {
-    const url = `https://tinyclouds${post.url}`;
+    const url = helpers.url(post.url, true);
     const date = new Date(post.publish_date).toUTCString();
 
     return `    <item>

--- a/feed.page.ts
+++ b/feed.page.ts
@@ -2,11 +2,7 @@ export const url = "/feed";
 
 export default function ({ search }: Lume.Data) {
   // Generate RSS content for /feed to match original tinyclouds.org
-  const posts = search.pages()
-    .filter((page) => page.title && page.publish_date)
-    .sort((a, b) =>
-      new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
-    );
+  const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
 
   const rssItems = posts.map((post) => {
     const url = `https://tinyclouds${post.url}`;

--- a/index.page.ts
+++ b/index.page.ts
@@ -3,7 +3,10 @@ export const title = "Ryan Dahl";
 export const url = "/";
 
 export default function ({ search }: Lume.Data) {
-  const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
+  const posts = search.pages(
+    "type=post publish_date!=undefined",
+    "publish_date=desc",
+  );
 
   return `
     <div class="header">

--- a/index.page.ts
+++ b/index.page.ts
@@ -26,12 +26,9 @@ export default function ({ search }: Lume.Data) {
       const formattedDate =
         new Date(post.publish_date).toISOString().split("T")[0];
 
-      // Fix the URL to remove /posts/ prefix
-      const cleanUrl = post.url.replace("/posts/", "/");
-
       return `
           <li>
-            <h2><a href="${cleanUrl}">${post.title}</a></h2>
+            <h2><a href="${post.url}">${post.title}</a></h2>
             <div class="post-date">${formattedDate}</div>
           </li>
         `;

--- a/index.page.ts
+++ b/index.page.ts
@@ -2,10 +2,10 @@ export const layout = "layout.tsx";
 export const title = "Ryan Dahl";
 export const url = "/";
 
-export default function* ({ search }: Lume.Data) {
+export default function ({ search }: Lume.Data) {
   const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
 
-  const content = `
+  return `
     <div class="header">
       <img src="/ry.jpg" alt="Ryan Dahl" class="avatar">
       <div class="header-content">
@@ -39,11 +39,4 @@ export default function* ({ search }: Lume.Data) {
   }
     </ul>
   `;
-
-  yield {
-    url: "/",
-    title: "Ryan Dahl",
-    layout: "layout.tsx",
-    content: content,
-  };
 }

--- a/index.page.ts
+++ b/index.page.ts
@@ -2,11 +2,11 @@ export const layout = "layout.tsx";
 export const title = "Ryan Dahl";
 export const url = "/";
 
-export default function* ({ search }: { search: any }) {
+export default function* ({ search }: Lume.Data) {
   const allPages = search.pages();
   const posts = allPages
-    .filter((page: any) => page.title && page.publish_date)
-    .sort((a: any, b: any) =>
+    .filter((page) => page.title && page.publish_date)
+    .sort((a, b) =>
       new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
     );
 
@@ -27,7 +27,7 @@ export default function* ({ search }: { search: any }) {
     
     <ul class="post-list">
       ${
-    posts.map((post: any) => {
+    posts.map((post) => {
       const formattedDate =
         new Date(post.publish_date).toISOString().split("T")[0];
 

--- a/index.page.ts
+++ b/index.page.ts
@@ -3,12 +3,7 @@ export const title = "Ryan Dahl";
 export const url = "/";
 
 export default function* ({ search }: Lume.Data) {
-  const allPages = search.pages();
-  const posts = allPages
-    .filter((page) => page.title && page.publish_date)
-    .sort((a, b) =>
-      new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
-    );
+  const posts = search.pages("type=post publish_date!=undefined", "publish_date=desc");
 
   const content = `
     <div class="header">

--- a/posts/_data.yml
+++ b/posts/_data.yml
@@ -1,0 +1,3 @@
+layout: post.tsx
+type: post
+basename: ""

--- a/posts/city_worker_exchange_program.md
+++ b/posts/city_worker_exchange_program.md
@@ -1,7 +1,6 @@
 ---
 title: City Worker Exchange Program
 publish_date: 2022-08-04
-layout: post.tsx
 ---
 
 An international exchange program should be established for workers in local

--- a/posts/colorize.md
+++ b/posts/colorize.md
@@ -1,7 +1,6 @@
 ---
 title: Automatic Colorization
 publish_date: 2016-01-08
-layout: post.tsx
 ---
 
 Have you seen Reddit's

--- a/posts/iocp_links.md
+++ b/posts/iocp_links.md
@@ -1,7 +1,6 @@
 ---
 title: Asynchronous I/O in Windows for Unix Programmers
 publish_date: 2011-04-26
-layout: post.tsx
 ---
 
 This document was an attempt at understanding how best to port Node.js to

--- a/posts/javascript_containers.md
+++ b/posts/javascript_containers.md
@@ -1,7 +1,6 @@
 ---
 title: JavaScript Containers
 publish_date: 2022-05-04
-layout: post.tsx
 ---
 
 The majority of server programs are Linux programs. They consist of a file

--- a/posts/optimistic_nihilism.md
+++ b/posts/optimistic_nihilism.md
@@ -3,7 +3,6 @@ title: Optimistic Nihilism
 publish_date: 2017-10-22
 cover_html: <svg class="w-full" height="350" width="100%" background="black"><circle cx="50%" cy="170" r="150" stroke="white" stroke-width="10" fill="black" alpha="50%"/></svg>
 background: "#eef"
-layout: post.tsx
 ---
 
 This post is in response to the

--- a/posts/rant.md
+++ b/posts/rant.md
@@ -1,7 +1,6 @@
 ---
 title: I hate almost all software
 publish_date: 2011-09-29
-layout: post.tsx
 ---
 
 It's unnecessary and complicated at almost every layer. At best I can

--- a/posts/residency.md
+++ b/posts/residency.md
@@ -2,7 +2,6 @@
 title: Google Brain Residency
 publish_date: 2017-06-06
 background: white
-layout: post.tsx
 ---
 
 Last year, after [nerding](http://tinyclouds.org/colorize/)

--- a/posts/trademark.md
+++ b/posts/trademark.md
@@ -1,7 +1,6 @@
 ---
 title: Dear Oracle, Please Release the JavaScript Trademark
 publish_date: 2022-09-03
-layout: post.tsx
 ---
 
 [In 1995 Netscape partnered with Sun Microsystems to create interactive

--- a/posts/underestimating-ai.md
+++ b/posts/underestimating-ai.md
@@ -1,7 +1,6 @@
 ---
 title: We're Still Underestimating What AI Really Means
 publish_date: 2025-06-14
-layout: post.tsx
 ---
 
 Most people are focused on short-term gains. Another tech wave, another startup


### PR DESCRIPTION
Hi. I just made some changes:

- Moved the posts files into the `/posts` folder. The `_data.yml` file assigns the same layout to all pages, the `type=post` variable is used to filter the posts by the `search` helper and the empty `basename` removes the `/posts` part to the output URLs.
- Use Lume types instead of `any`
- Fixed the url configuration
