### PR TITLE
fix(theme): fix null reference error by executing theme script after DOM loads

### DIFF
--- a/_includes/layout.tsx
+++ b/_includes/layout.tsx
@@ -19,22 +19,6 @@ export default function Layout(
           title="Ryan Dahl"
           href="/feed"
         />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-            function toggleTheme() {
-              document.body.classList.toggle('dark');
-              localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
-            }
-            
-            // Apply saved theme on load
-            if (localStorage.getItem('theme') === 'dark' || 
-                (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-              document.body.classList.add('dark');
-            }
-          `,
-          }}
-        />
         <style
           dangerouslySetInnerHTML={{
             __html: `
@@ -299,6 +283,22 @@ export default function Layout(
         <div class="container">
           {children}
         </div>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            function toggleTheme() {
+              document.body.classList.toggle('dark');
+              localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+            }
+
+            // Apply saved theme on load
+            if (localStorage.getItem('theme') === 'dark' || 
+                (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+              document.body.classList.add('dark');
+            }
+          `,
+          }}
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## What does this PR do?
This PR resolves a runtime reference error in which the theme initialization script executed before the `body element` was fully parsed and available in the DOM. By moving the inline script from the `<head>` element to the end of the `<body>` element, we guarantee that `document.body` is fully instantiated before the script attempts to read or modify its class list.